### PR TITLE
Feature/build compose

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+        extra = "ignore"  # 추가: 정의되지 않은 env 변수 무시
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:latest
+    container_name: my-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - ${POSTGRES_DATA_VOLUME}:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT}:5432"
+
+  redis:
+    image: redis:latest
+    container_name: redis-cache
+    ports:
+      - "${REDIS_PORT}:6379"
+
+  fastapi-app:
+    build: .
+    container_name: my-fastapi-app
+    ports:
+      - "8000:8000"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_HOST: my-postgres
+      POSTGRES_PORT: 5432
+      REDIS_HOST: redis-cache
+      REDIS_PORT: 6379
+      FAISS: ${FAISS}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    depends_on:
+      - postgres
+      - redis


### PR DESCRIPTION
##진행 내용
Postgres, Redis, FastAPI (Dockerfile 포함)를 하나의 Docker Compose 파일로 구성

## TODO

- [x]  포트, 비밀번호 등 주요 환경 변수 .env 파일로 분리
- [x]  FastAPI에서 사용하지 않는 .env 변수는 무시되도록 app/core/config.py에 extra = "ignore" 설정
- [x]  Docker Compose 파일 빌드 및 실행 테스트

